### PR TITLE
Fix update thc job

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -21,7 +21,7 @@ dependencies:
   id:              thc
   uses:            docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
   with:
-    glob:       thc-.+-amd64_linux.tar.xz
-    owner:      thc
-    repository: thc
+    glob:       thc-x86_64-unknown-linux-musl
+    owner:      dmikusa
+    repository: tiny-health-checker
     token:      ${{ secrets.JAVA_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-tiny-health-checker.yml
+++ b/.github/workflows/pb-update-tiny-health-checker.yml
@@ -44,9 +44,9 @@ jobs:
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
               with:
-                glob: thc-.+-amd64_linux.tar.xz
-                owner: thc
-                repository: thc
+                glob: thc-x86_64-unknown-linux-musl
+                owner: dmikusa
+                repository: tiny-health-checker
                 token: ${{ secrets.JAVA_GITHUB_TOKEN }}
             - name: Update Buildpack Dependency
               id: buildpack


### PR DESCRIPTION
The repo info was wrong for the action that checks for new releases of thc. This points it to the correct place and updates the workflows.

Signed-off-by: Daniel Mikusa <dan@mikusa.com>
