### PR TITLE
Move environment variables into layer creator

### DIFF
--- a/hc/build_test.go
+++ b/hc/build_test.go
@@ -17,8 +17,6 @@
 package hc_test
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/buildpacks/libcnb"
@@ -38,7 +36,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Application.Path, err = ioutil.TempDir("", "build")
+		ctx.Application.Path = t.TempDir()
 		Expect(err).NotTo(HaveOccurred())
 
 		ctx.Plan.Entries = append(ctx.Plan.Entries, libcnb.BuildpackPlanEntry{Name: "hc"})
@@ -52,10 +50,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			},
 		}
 		ctx.StackID = "test-stack-id"
-	})
-
-	it.After(func() {
-		Expect(os.RemoveAll(ctx.Application.Path)).To(Succeed())
 	})
 
 	it("contributes tiny health checker", func() {

--- a/hc/tiny_health_checker.go
+++ b/hc/tiny_health_checker.go
@@ -46,13 +46,6 @@ func NewTinyHealthChecker(dependency libpak.BuildpackDependency, cache libpak.De
 func (t TinyHealthChecker) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 	t.LayerContributor.Logger = t.Logger
 
-	// if set at build time, we bake them into the image, user can override at runtime
-	for _, envVarName := range []string{"THC_PORT", "THC_PATH", "CONN_TIMEOUT", "REQ_TIMEOUT"} {
-		if val, found := t.ConfigResolver.Resolve(envVarName); found {
-			layer.LaunchEnvironment.ProcessDefault("health-check", envVarName, val)
-		}
-	}
-
 	return t.LayerContributor.Contribute(layer, func(artifact *os.File) (libcnb.Layer, error) {
 		binDir := filepath.Join(layer.Path, "bin")
 
@@ -69,6 +62,13 @@ func (t TinyHealthChecker) Contribute(layer libcnb.Layer) (libcnb.Layer, error) 
 
 		if err := os.Chmod(hcBin, 0775); err != nil {
 			return libcnb.Layer{}, fmt.Errorf("unable to `chmod 775` binary %s\n%w", hcBin, err)
+		}
+
+		// if set at build time, we bake them into the image, user can override at runtime
+		for _, envVarName := range []string{"THC_PORT", "THC_PATH", "CONN_TIMEOUT", "REQ_TIMEOUT"} {
+			if val, found := t.ConfigResolver.Resolve(envVarName); found {
+				layer.LaunchEnvironment.ProcessDefault("health-check", envVarName, val)
+			}
 		}
 
 		return layer, nil

--- a/hc/tiny_health_checker_test.go
+++ b/hc/tiny_health_checker_test.go
@@ -17,7 +17,6 @@
 package hc_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,12 +39,8 @@ func testTinyHealthChecker(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Layers.Path, err = ioutil.TempDir("", "thc-layers")
+		ctx.Layers.Path = t.TempDir()
 		Expect(err).NotTo(HaveOccurred())
-	})
-
-	it.After(func() {
-		Expect(os.RemoveAll(ctx.Layers.Path)).To(Succeed())
 	})
 
 	it("contributes health checker", func() {


### PR DESCRIPTION
This commit moves where the environment variables are being set to inside of the layer creator. The environment variables are attached to the layer, so they should be set in the layer creator. That way they are all of the actions happen when the layer is recrated and only when the layer is recreated. The environment variables do not need to be set every time the contributor runs, just when the layer metadata changes.

Also, cleans up some ioutil calls.

Signed-off-by: Daniel Mikusa <dan@mikusa.com>
