### PR TITLE
Add ARM64 dependency

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 the original author or authors.
+# Copyright 2018-2024 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,8 +51,24 @@ api = "0.7"
     sha256 = "8c361a4e7850b4e274dda21bb4ee49dd5fe8374220330a855ecacb43e7a12869"
     source = "https://github.com/dmikusa/tiny-health-checker/archive/refs/tags/v0.22.0.tar.gz"
     source-sha256 = "054ce7d290ad2839828cf9f9b24b32edc216abde2f9f167843def03402688858"
-    stacks = ["io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny", "*"]
+    stacks = ["*"]
     uri = "https://github.com/dmikusa/tiny-health-checker/releases/download/v0.22.0/thc-x86_64-unknown-linux-musl"
+    version = "0.22.0"
+
+    [[metadata.dependencies.licenses]]
+      type = "Apache-2"
+      uri = "https://github.com/dmikusa-pivotal/tiny-health-checker/blob/main/LICENSE"
+
+  [[metadata.dependencies]]
+    cpes = ["cpe:2.3:a:dmikusa-pivotal:tiny-health-checker:0.22.0:*:*:*:*:*:*:*"]
+    id = "thc"
+    name = "Tiny Health Checker"
+    purl = "pkg:generic/thc@0.22.0?arch=arm64"
+    sha256 = "bad"
+    source = "https://github.com/dmikusa/tiny-health-checker/archive/refs/tags/v0.22.0.tar.gz"
+    source-sha256 = "054ce7d290ad2839828cf9f9b24b32edc216abde2f9f167843def03402688858"
+    stacks = ["*"]
+    uri = "bad"
     version = "0.22.0"
 
     [[metadata.dependencies.licenses]]


### PR DESCRIPTION
## Summary
Adds the ARM64 dependency. It is expected to have bad info as we're going to let the pipeline run and update it.

## Use Cases

ARM64 support.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
