### PR TITLE
Remove process type

### DIFF
--- a/hc/build.go
+++ b/hc/build.go
@@ -24,10 +24,6 @@ import (
 	"github.com/paketo-buildpacks/libpak/bard"
 )
 
-type ProcessContributor interface {
-	ContributeProcesses() []libcnb.Process
-}
-
 type Build struct {
 	Logger bard.Logger
 }
@@ -63,11 +59,10 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 			return libcnb.BuildResult{}, fmt.Errorf("unable to find dependency\n%w", err)
 		}
 
-		hcLayercontributor := NewTinyHealthChecker(hcDependency, dc, cr)
+		hcLayercontributor := NewTinyHealthChecker(hcDependency, dc, cr, context.Application.Path)
 		hcLayercontributor.Logger = b.Logger
 
 		result.Layers = append(result.Layers, hcLayercontributor)
-		result.Processes = hcLayercontributor.ContributeProcesses()
 	}
 
 	return result, nil

--- a/hc/build_test.go
+++ b/hc/build_test.go
@@ -75,10 +75,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(result.Layers).To(HaveLen(1))
 		Expect(result.Layers[0].Name()).To(Equal("thc"))
-		Expect(result.Processes[0].Type).To(Equal("health-check"))
-		Expect(result.Processes[0].Command).To(Equal("thc"))
-		Expect(result.Processes[0].Arguments).To(HaveLen(0))
-		Expect(result.Processes[0].Default).To(BeFalse())
-		Expect(result.Processes[0].Direct).To(BeTrue())
+		Expect(result.Processes).To(HaveLen(0))
 	})
 }


### PR DESCRIPTION
## Summary

This PR removes the process type contributed by the health checker buildpack. This was problematic in that it would trigger the exec.d helpers to run every time the health check was run, which caused issues.

Instead, we install the health check binary, print the path at which it's installed and one can invoke it directly. Then we attempt to create a symlink to the health check binary under `/workspace/health-check`. This is then the shortcut that one can use to easily invoke the health check binary.

This is flagged as a major change as it removes the process type, which could break health checks for users if they are invoking the process type.

## Use Cases

Resolves #134 

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
