### PR TITLE
Revert "Bump Tiny Health Checker from 0.37.0 to 0.36.0"

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -44,16 +44,16 @@ api = "0.7"
     name = "BP_HEALTH_CHECKER_DEPENDENCY"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:dmikusa-pivotal:tiny-health-checker:0.36.0:*:*:*:*:*:*:*"]
+    cpes = ["cpe:2.3:a:dmikusa-pivotal:tiny-health-checker:0.37.0:*:*:*:*:*:*:*"]
     id = "thc"
     name = "Tiny Health Checker"
-    purl = "pkg:generic/thc@0.36.0?arch=amd64"
-    sha256 = "a738377a8976b90ca030af644a3b987fc4984b94891c6eb38c6a8a002e58f4f8"
-    source = "https://github.com/dmikusa/tiny-health-checker/archive/refs/tags/v0.36.0.tar.gz"
-    source-sha256 = "7c95d59aaf7c3698b6625d9d894185a06dab8eff0af4c7bffcdbadbdf3c6266e"
+    purl = "pkg:generic/thc@0.37.0?arch=amd64"
+    sha256 = "95b2464695730a417fd8efe6b6146e7e1b6ffc7b04f43bd9c31ca90dce002eef"
+    source = "https://github.com/dmikusa/tiny-health-checker/archive/refs/tags/v0.37.0.tar.gz"
+    source-sha256 = "8bec2bfa3970027009c12dd9afe7721f6cd8c65cb0fe9c72173e892edfef60e6"
     stacks = ["*"]
-    uri = "https://github.com/dmikusa/tiny-health-checker/releases/download/v0.36.0/thc-x86_64-unknown-linux-musl"
-    version = "0.36.0"
+    uri = "https://github.com/dmikusa/tiny-health-checker/releases/download/v0.37.0/tiny-health-checker-x86_64-unknown-linux-musl.tar.xz"
+    version = "0.37.0"
 
     [[metadata.dependencies.licenses]]
       type = "Apache-2"


### PR DESCRIPTION
Reverts paketo-buildpacks/health-checker#186