### PR TITLE
Revert "Bump Tiny Health Checker ARM64 from 0.37.0 to 0.36.0"

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -60,16 +60,16 @@ api = "0.7"
       uri = "https://github.com/dmikusa-pivotal/tiny-health-checker/blob/main/LICENSE"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:dmikusa-pivotal:tiny-health-checker:0.36.0:*:*:*:*:*:*:*"]
+    cpes = ["cpe:2.3:a:dmikusa-pivotal:tiny-health-checker:0.37.0:*:*:*:*:*:*:*"]
     id = "thc"
     name = "Tiny Health Checker"
-    purl = "pkg:generic/thc@0.36.0?arch=arm64"
-    sha256 = "e4c6c4691ad4b7724e9e8a179a0da5cb46e337a7bf2227cf7f5d1c102bef1046"
-    source = "https://github.com/dmikusa/tiny-health-checker/archive/refs/tags/v0.36.0.tar.gz"
-    source-sha256 = "7c95d59aaf7c3698b6625d9d894185a06dab8eff0af4c7bffcdbadbdf3c6266e"
+    purl = "pkg:generic/thc@0.37.0?arch=arm64"
+    sha256 = "b72143c06dc8067e188cdc083736dd81e52eb015db770ddc2969294a2d4a71ba"
+    source = "https://github.com/dmikusa/tiny-health-checker/archive/refs/tags/v0.37.0.tar.gz"
+    source-sha256 = "8bec2bfa3970027009c12dd9afe7721f6cd8c65cb0fe9c72173e892edfef60e6"
     stacks = ["*"]
-    uri = "https://github.com/dmikusa/tiny-health-checker/releases/download/v0.36.0/thc-aarch64-unknown-linux-musl"
-    version = "0.36.0"
+    uri = "https://github.com/dmikusa/tiny-health-checker/releases/download/v0.37.0/tiny-health-checker-aarch64-unknown-linux-musl.tar.xz"
+    version = "0.37.0"
 
     [[metadata.dependencies.licenses]]
       type = "Apache-2"


### PR DESCRIPTION
Reverts paketo-buildpacks/health-checker#185